### PR TITLE
Add include path for LAPACKE on Fedora

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ else:
     # assume linux otherwise, unless we support Windows in the future...
     print("Platform Detection: Linux. Link to liblapacke...")
     extra_link_args = ['-llapacke -llapack -lblas']
-    include_dirs = numpy.distutils.misc_util.get_numpy_include_dirs()
+    include_dirs = (numpy.distutils.misc_util.get_numpy_include_dirs() +
+                    ['/usr/include/lapacke'])
 
 setup(
     name='libact',


### PR DESCRIPTION
appears that the include path of lapacke.h cannot be automatically found on my Fedora, hence modified similar to Mac