### PR TITLE
[MRG] Correct quota comment

### DIFF
--- a/examples/label_digits.py
+++ b/examples/label_digits.py
@@ -47,7 +47,7 @@ def split_train_test(n_classes):
 
 
 def main():
-    quota = 10  # ask human to label 30 samples
+    quota = 10  # ask human to label 10 samples
     n_classes = 5
     E_out1, E_out2 = [], []
 


### PR DESCRIPTION
This corrects the issue brought up in #50. Particularly:

> 1: in the main function, " quota = 10 # ask human to label 30 samples" the value 10 and 30 is confusing, is there a typo?

to which the response was:

> 1. Yes, it is a typo. (sorry about that)