### PR TITLE
move unittest of QUIRE to a seperated class

### DIFF
--- a/libact/query_strategies/tests/test_quire.py
+++ b/libact/query_strategies/tests/test_quire.py
@@ -1,0 +1,28 @@
+import unittest
+
+from numpy.testing import assert_array_equal
+import numpy as np
+
+from libact.base.dataset import Dataset
+from libact.query_strategies import QUIRE
+from .utils import run_qs
+
+
+class QUIRETestCase(unittest.TestCase):
+    """QUIRE test case using artifitial dataset"""
+    def setUp(self):
+        self.X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [0, 1],
+                  [0, -2], [1.5, 1.5], [-2, -2]]
+        self.y = [-1, -1, -1, 1, 1, 1, -1, -1, 1, 1]
+        self.quota = 4
+
+    def test_quire(self):
+        trn_ds = Dataset(self.X, np.concatenate([self.y[:6], [None] * 4]))
+        qs = QUIRE(trn_ds)
+        qseq = run_qs(trn_ds, qs, self.y, self.quota)
+        assert_array_equal(qseq, np.array([6, 7, 9, 8]))
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/libact/query_strategies/tests/test_uncertainty_sampling.py
+++ b/libact/query_strategies/tests/test_uncertainty_sampling.py
@@ -73,13 +73,6 @@ class UncertaintySamplingTestCase(unittest.TestCase):
             qs = UncertaintySampling(
                     trn_ds, method='not_exist', model=LogisticRegression())
 
-    def test_quire(self):
-        trn_ds = init_toyexample(self.X, self.y)
-        qs = QUIRE(trn_ds)
-        model = LogisticRegression()
-        qseq = run_qs(trn_ds, self.lbr, model, qs, self.quota)
-        assert_array_equal(qseq, np.array([6, 7, 9, 8]))
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The test case of QUIRE should not contained in unit test of uncertainty sampling.