### PR TITLE
supporting different sklearn version

### DIFF
--- a/examples/albl_plot.py
+++ b/examples/albl_plot.py
@@ -9,7 +9,10 @@ import os
 
 import numpy as np
 import matplotlib.pyplot as plt
-from sklearn.cross_validation import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 
 # libact classes
 from libact.base.dataset import Dataset, import_libsvm_sparse

--- a/examples/alce_plot.py
+++ b/examples/alce_plot.py
@@ -10,7 +10,10 @@ import numpy as np
 import matplotlib
 matplotlib.use('tkAgg')
 import matplotlib.pyplot as plt
-from sklearn.model_selection import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 from sklearn.preprocessing import StandardScaler
 import sklearn.datasets
 from sklearn.svm import SVR

--- a/examples/label_digits.py
+++ b/examples/label_digits.py
@@ -16,7 +16,10 @@ import copy
 
 import numpy as np
 import matplotlib.pyplot as plt
-from sklearn.cross_validation import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 
 # libact classes
 from libact.base.dataset import Dataset

--- a/examples/multilabel_plot.py
+++ b/examples/multilabel_plot.py
@@ -10,7 +10,10 @@ import numpy as np
 import matplotlib
 matplotlib.use('tkAgg')
 import matplotlib.pyplot as plt
-from sklearn.model_selection import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from sklearn.datasets import make_multilabel_classification
 

--- a/examples/plot.py
+++ b/examples/plot.py
@@ -10,7 +10,10 @@ import os
 
 import numpy as np
 import matplotlib.pyplot as plt
-from sklearn.cross_validation import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 
 # libact classes
 from libact.base.dataset import Dataset, import_libsvm_sparse

--- a/libact/models/multilabel/tests/test_binary_relevance.py
+++ b/libact/models/multilabel/tests/test_binary_relevance.py
@@ -5,7 +5,10 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_equal
 from sklearn import datasets
-from sklearn.model_selection import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 import sklearn.linear_model
 
 from libact.base.dataset import Dataset

--- a/libact/models/sklearn_adapter.py
+++ b/libact/models/sklearn_adapter.py
@@ -18,7 +18,7 @@ class SklearnAdapter(Model):
     .. code-block:: python
 
        from sklearn import datasets
-       from sklearn.cross_validation import train_test_split
+       from sklearn.model_selection import train_test_split
        from sklearn.linear_model import LogisticRegression
 
        from libact.base.dataset import Dataset
@@ -66,7 +66,7 @@ class SklearnProbaAdapter(ProbabilisticModel):
     .. code-block:: python
 
        from sklearn import datasets
-       from sklearn.cross_validation import train_test_split
+       from sklearn.model_selection import train_test_split
        from sklearn.linear_model import LogisticRegression
 
        from libact.base.dataset import Dataset

--- a/libact/models/tests/test_logistic_regression.py
+++ b/libact/models/tests/test_logistic_regression.py
@@ -7,7 +7,10 @@ import unittest
 
 from numpy.testing import assert_array_equal
 from sklearn import datasets
-from sklearn.cross_validation import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 import sklearn.linear_model
 
 from libact.base.dataset import Dataset

--- a/libact/models/tests/test_perceptron.py
+++ b/libact/models/tests/test_perceptron.py
@@ -7,7 +7,10 @@ import unittest
 
 from numpy.testing import assert_array_equal
 from sklearn import datasets
-from sklearn.cross_validation import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 import sklearn.linear_model
 
 from libact.base.dataset import Dataset

--- a/libact/models/tests/test_sklearn_adapter.py
+++ b/libact/models/tests/test_sklearn_adapter.py
@@ -4,7 +4,10 @@ import unittest
 
 from numpy.testing import assert_array_equal
 from sklearn import datasets
-from sklearn.cross_validation import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import LinearSVC
 from sklearn.neighbors import KNeighborsClassifier

--- a/libact/models/tests/test_svm.py
+++ b/libact/models/tests/test_svm.py
@@ -7,7 +7,10 @@ import unittest
 
 from numpy.testing import assert_array_equal
 from sklearn import datasets
-from sklearn.cross_validation import train_test_split
+try:
+    from sklearn.model_selection import train_test_split
+except ImportError:
+    from sklearn.cross_validation import train_test_split
 from sklearn.svm import SVC
 
 from libact.base.dataset import Dataset


### PR DESCRIPTION
sklearn.cross_validation changed name to sklearn.model_selection in sklearn v0.18.