### PR TITLE
Use `brew install openblas` for macOS dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sudo apt-get install build-essential gfortran libatlas-base-dev liblapacke-dev p
 
 * macOS
 ```
-brew install homebrew/science/openblas
+brew install openblas
 ```
 
 # Installation


### PR DESCRIPTION
Brew maintainers have deprecated `homebrew/science/openblas` package,
```sh
$❯ brew info homebrew/science/openblas
Warning: Use openblas instead of deprecated homebrew/science/openblas
…
```
This commit updated the README.md with updated instruction for managing
dependencies on macOS, i.e. use `brew install openblas`