### PR TITLE
Update MANIFEST.in to include requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ recursive-include libact *.pyx *.pxd *.h
 include README.md
 include LICENSE
 include libact/query_strategies/src/hintsvm/COPYRIGHT
+include requirements.txt


### PR DESCRIPTION
Running pip install of the package fails on my machine because requirements.txt is missing. This PR adds it.