### PR TITLE
ideal_labeler when matching multiple input vectors

### DIFF
--- a/libact/labelers/ideal_labeler.py
+++ b/libact/labelers/ideal_labeler.py
@@ -29,5 +29,6 @@ class IdealLabeler(Labeler):
 
     @inherit_docstring_from(Labeler)
     def label(self, feature):
-        return self.y[np.where([np.array_equal(x, feature)
-                                for x in self.X])[0][0]]
+        yy = self.y[np.where([np.array_equal(x, feature)
+                              for x in self.X])[0]]
+        return np.random.choice(yy, 1)[0]


### PR DESCRIPTION
make ideal_labeler return a randomly chosen label instead of first label when matching multiple input vectors