### PR TITLE
[MRG] Upgrade to support newest scikit-learn version

### DIFF
--- a/libact/models/tests/test_svm.py
+++ b/libact/models/tests/test_svm.py
@@ -29,7 +29,7 @@ class SVMIrisTestCase(unittest.TestCase):
     def test_svm(self):
         svc_clf = SVC(gamma="auto")
         svc_clf.fit(self.X_train, self.y_train)
-        svm = SVM()
+        svm = SVM(gamma="auto")
         svm.train(Dataset(self.X_train, self.y_train))
 
         assert_array_equal(

--- a/libact/query_strategies/multiclass/mdsp.py
+++ b/libact/query_strategies/multiclass/mdsp.py
@@ -16,8 +16,8 @@ import warnings
 from sklearn.base import BaseEstimator
 from sklearn.metrics import euclidean_distances
 from sklearn.utils import check_random_state, check_array, check_symmetric
-from sklearn.externals.joblib import Parallel
-from sklearn.externals.joblib import delayed
+from joblib import Parallel
+from joblib import delayed
 from sklearn.isotonic import IsotonicRegression
 
 

--- a/libact/query_strategies/multiclass/tests/test_hierarchical_sampling.py
+++ b/libact/query_strategies/multiclass/tests/test_hierarchical_sampling.py
@@ -29,8 +29,8 @@ class HierarchicalSamplingTestCase(unittest.TestCase):
         qseq = run_qs(ds, qs, self.y, len(self.y)-10)
         assert_array_equal(
             np.concatenate([qseq[:10], qseq[-10:]]),
-            np.array([48, 143, 13, 142, 88, 130, 29, 87, 36, 28,
-                      58, 137, 49, 105, 76, 71, 63, 47, 64, 55])
+            np.array([39, 126, 66, 135,  37, 33, 118, 132, 142, 144,
+                      71,  28, 63,  41, 140, 34,  20, 110, 136,  36])
             )
 
     def test_hs_active_selecting(self):
@@ -39,8 +39,8 @@ class HierarchicalSamplingTestCase(unittest.TestCase):
         qseq = run_qs(ds, qs, self.y, len(self.y)-10)
         assert_array_equal(
             np.concatenate([qseq[:10], qseq[-10:]]),
-            np.array([48, 143, 13, 64, 101, 108, 51, 87, 36, 28,
-                      43, 118, 47, 25, 81, 82, 95, 40, 67, 120])
+            np.array([39, 126, 66, 135, 37, 33, 118, 132, 142, 144,
+                      89, 117, 48,  67, 75, 14,  79,  62, 105,  19])
             )
 
     def test_hs_subsampling(self):
@@ -51,8 +51,8 @@ class HierarchicalSamplingTestCase(unittest.TestCase):
         qseq = run_qs(ds, qs, self.y, len(self.y)-10)
         assert_array_equal(
             np.concatenate([qseq[:10], qseq[-10:]]),
-            np.array([120, 50, 33, 28, 78, 133, 52, 124, 102, 109,
-                      81, 108, 12, 10, 89, 114, 92, 126, 48, 25])
+            np.array([120,  50, 33, 28,  78, 133, 52, 124, 102, 109,
+                       81, 108, 10, 89, 126, 114, 92,  48,  25,  13])
             )
 
     def test_hs_report_all_label(self):

--- a/libact/query_strategies/multilabel/tests/test_multilabel_realdata.py
+++ b/libact/query_strategies/multilabel/tests/test_multilabel_realdata.py
@@ -47,7 +47,7 @@ class MultilabelRealdataTestCase(unittest.TestCase):
         qs = MMC(trn_ds, random_state=1126)
         qseq = run_qs(trn_ds, qs, self.y, self.quota)
         assert_array_equal(qseq,
-                np.array([117, 655, 1350, 909, 1003, 1116, 546, 1055, 165, 1441]))
+                np.array([117,  655,  234, 1419, 1350, 1224,  427,  890, 1447,  103]))
 
     def test_multilabel_with_auxiliary_learner_hlr(self):
         trn_ds = Dataset(self.X,

--- a/libact/query_strategies/tests/test_density_weighted_meta.py
+++ b/libact/query_strategies/tests/test_density_weighted_meta.py
@@ -37,7 +37,7 @@ class DensityWeightedMetaTestCase(unittest.TestCase):
             beta=1.0, random_state=1126)
         model = LogisticRegression(solver='liblinear', multi_class="ovr")
         qseq = run_qs(trn_ds, qs, self.y, self.quota)
-        assert_array_equal(qseq, np.array([13, 18,  9, 12,  8, 16, 10, 19, 15, 17]))
+        assert_array_equal(qseq, np.array([ 8,  9, 13, 18, 12, 16, 10, 19, 15,  6]))
 
 
 if __name__ == '__main__':

--- a/libact/query_strategies/tests/test_density_weighted_meta.py
+++ b/libact/query_strategies/tests/test_density_weighted_meta.py
@@ -37,7 +37,7 @@ class DensityWeightedMetaTestCase(unittest.TestCase):
             beta=1.0, random_state=1126)
         model = LogisticRegression(solver='liblinear', multi_class="ovr")
         qseq = run_qs(trn_ds, qs, self.y, self.quota)
-        assert_array_equal(qseq, np.array([ 8,  9, 13, 18, 12, 16, 10, 19, 15,  6]))
+        assert_array_equal(qseq, np.array([13, 18,  9, 12,  8, 16, 10, 19, 15, 17]))
 
 
 if __name__ == '__main__':

--- a/libact/query_strategies/tests/test_realdata.py
+++ b/libact/query_strategies/tests/test_realdata.py
@@ -153,7 +153,7 @@ class RealdataTestCase(unittest.TestCase):
         qs = DWUS(trn_ds, random_state=1126)
         qseq = run_qs(trn_ds, qs, self.y, self.quota)
         assert_array_equal(
-            qseq, np.array([179,  62,  69,  38, 263, 150, 162, 142,  79, 219]))
+            qseq, np.array([ 30, 179, 104, 186,  28,  65, 142,  62, 257, 221]))
 
 
 if __name__ == '__main__':

--- a/libact/query_strategies/tests/test_realdata.py
+++ b/libact/query_strategies/tests/test_realdata.py
@@ -153,7 +153,7 @@ class RealdataTestCase(unittest.TestCase):
         qs = DWUS(trn_ds, random_state=1126)
         qseq = run_qs(trn_ds, qs, self.y, self.quota)
         assert_array_equal(
-            qseq, np.array([30, 179, 104, 186, 28, 65, 142, 62, 257, 221]))
+            qseq, np.array([179,  62,  69,  38, 263, 150, 162, 142,  79, 219]))
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 numpy
 scipy
-scikit-learn==0.20
+scikit-learn==0.22
 matplotlib
 Cython
 joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 numpy
 scipy
-scikit-learn==0.22
+scikit-learn==0.23
 matplotlib
 Cython
 joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 numpy
 scipy
-scikit-learn<=0.19.2
+scikit-learn==0.20
 matplotlib
 Cython
 joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools
 numpy
 scipy
-scikit-learn==0.23
+scikit-learn
 matplotlib
 Cython
 joblib


### PR DESCRIPTION
**Reference Issues/PRs**

No.

**What does this implement/fix? Explain your changes.**

When upgrading to sklearn==0.24.2, it occurs five FAILs during `python setup.py test`.

- Check why test FAILs occurs.
- Update the **test case** to pass it.

**Any other comments?**

- It's worth thinking about the efficient ways to upgrade when dependencies upgrade.
- Please see the comments below.