### PR TITLE
Fix compilation error and runtime warning for Python versions ≤ 3.6

### DIFF
--- a/libact/base/dataset.py
+++ b/libact/base/dataset.py
@@ -34,12 +34,14 @@ class Dataset(object):
     """
 
     def __init__(self, X=None, y=None):
-        if X is None: X = np.array([])
+        if X is None:
+            X = np.array([])
         elif not isinstance(X, sp.csr_matrix):
             X = np.array(X)
 
-        if y is None: y = []
-        y = np.array(y)
+        if y is None:
+            y = []
+        y = np.array(y, dtype=object)
 
         self._X = X
         self._y = y

--- a/libact/query_strategies/_hintsvm.pyx
+++ b/libact/query_strategies/_hintsvm.pyx
@@ -3,7 +3,7 @@
 import  numpy as np
 cimport numpy as np
 from libc.stdlib cimport free
-cimport _hintsvm
+from . cimport _hintsvm
 
 cdef extern from *:
     ctypedef struct svm_parameter:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools
+setuptools<60.0
 numpy
 scipy
 scikit-learn>=0.24


### PR DESCRIPTION
This pull request:
1. fixes the issue on line 6 in `libact/query_strategies/_hintsvm.pyx` that leads to the compilation error mentioned in #193.
2. addresses the `VisibleDeprecationWarning` by explicitly adding `dtype=object` to line 44 in `libact/base/dataset.py`.
3. specifies a version upper bound for `setuptools` to ensure successful installation.