### PR TITLE
﻿Fix native-extension CI checks and switch linting to Ruff

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,28 +1,30 @@
-name: Libact linting
+name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.9']
+  ruff:
+    name: Ruff correctness checks
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Run Ruff
+        uses: astral-sh/ruff-action@v3
         with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pylint
-
-      - name: Run pylint (errors only)
-        run: pylint --errors-only libact
+          version: "0.15.21"
+          args: check --output-format=github
+          src: "."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,25 +39,21 @@ jobs:
           pip install meson-python meson ninja cython numpy
       - name: Install libact in editable mode
         run: |
-          pip install --no-build-isolation -e . 2>&1 | tee build.log
+          python -m pip install --no-build-isolation -e .
       - name: Verify optional features were built
         run: |
-          # Check build log for feature messages
-          if grep -q "Building VarianceReduction" build.log; then
-            echo "✓ VarianceReduction feature was built"
-          else
-            echo "✗ ERROR: VarianceReduction feature was NOT built (expected with BLAS/LAPACK)"
-            exit 1
-          fi
-          if grep -q "Building HintSVM" build.log; then
-            echo "✓ HintSVM feature was built"
-          else
-            echo "✗ ERROR: HintSVM feature was NOT built (expected with BLAS/LAPACK)"
-            exit 1
-          fi
-          # Verify the compiled modules are importable
-          python -c "from libact.query_strategies._variance_reduction import *; print('✓ _variance_reduction module imports successfully')"
-          python -c "from libact.query_strategies._hintsvm import *; print('✓ _hintsvm module imports successfully')"
+          python - <<'PY'
+          from importlib import import_module
+
+          modules = (
+              "libact.query_strategies._variance_reduction",
+              "libact.query_strategies._hintsvm",
+          )
+
+          for module in modules:
+              import_module(module)
+              print(f"✓ {module} imports successfully")
+          PY
       - name: Run unittests
         run: |
           python -m unittest -v
@@ -98,41 +94,29 @@ jobs:
           pip install meson-python meson ninja cython numpy
       - name: Install libact (should skip variance_reduction and hintsvm)
         run: |
-          pip install --no-build-isolation -e . 2>&1 | tee install.log
+          python -m pip install --no-build-isolation -e .
       - name: Verify optional features were skipped
         run: |
-          # Verify warning message appears
-          if grep -q "BLAS/LAPACK libraries not found" install.log; then
-            echo "✓ BLAS/LAPACK warning message found (as expected)"
-          else
-            echo "✗ WARNING: Expected BLAS/LAPACK warning message not found"
-          fi
-          # Verify features were skipped
-          if grep -q "Skipping VarianceReduction" install.log; then
-            echo "✓ VarianceReduction was correctly skipped"
-          else
-            echo "✗ ERROR: VarianceReduction skip message not found"
-            exit 1
-          fi
-          if grep -q "Skipping HintSVM" install.log; then
-            echo "✓ HintSVM was correctly skipped"
-          else
-            echo "✗ ERROR: HintSVM skip message not found"
-            exit 1
-          fi
-          # Verify the modules don't exist (shouldn't be importable)
-          python -c "try:
-    from libact.query_strategies._variance_reduction import *
-    print('✗ ERROR: _variance_reduction should not be importable without BLAS')
-    exit(1)
-except ImportError:
-    print('✓ _variance_reduction correctly not available (as expected)')" || exit 1
-          python -c "try:
-    from libact.query_strategies._hintsvm import *
-    print('✗ ERROR: _hintsvm should not be importable without BLAS')
-    exit(1)
-except ImportError:
-    print('✓ _hintsvm correctly not available (as expected)')" || exit 1
+          # Verify only the expected native modules are unavailable. Unrelated
+          # import failures must still fail this step.
+          python - <<'PY'
+          from importlib import import_module
+
+          modules = (
+              "libact.query_strategies._variance_reduction",
+              "libact.query_strategies._hintsvm",
+          )
+
+          for module in modules:
+              try:
+                  import_module(module)
+              except ModuleNotFoundError as error:
+                  if error.name != module:
+                      raise
+                  print(f"✓ {module} correctly not available (as expected)")
+              else:
+                  raise SystemExit(f"✗ ERROR: {module} should not be importable without BLAS")
+          PY
       - name: Test basic import
         run: |
           python -c "from libact.base.dataset import Dataset; print('SUCCESS: Basic import works without BLAS/LAPACK')"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,6 @@
 
 import sys
 import os
-import shlex
-import sys
 from unittest.mock import MagicMock
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,20 @@ dependencies = [
 Homepage = "https://github.com/ntucllab/libact"
 Repository = "https://github.com/ntucllab/libact"
 
+# Lint for correctness without making existing legacy style debt blocking.
+[tool.ruff]
+target-version = "py39"
+extend-exclude = ["docs/_build"]
+
+[tool.ruff.lint]
+select = ["E9", "F", "LOG", "RUF100"]
+
+[tool.ruff.lint.per-file-ignores]
+# These directories have pre-existing unused imports and locals. Other
+# Pyflakes findings remain blocking; F401/F841 still apply everywhere else.
+"examples/**/*.py" = ["F401", "F841"]
+"libact/**/*.py" = ["F401", "F841"]
+
 [project.optional-dependencies]
 dev = ["build>=1.2.2.post1", "meson>=1.5.0", "ninja", "cython", "numpy"]
 


### PR DESCRIPTION
﻿Makes the native-extension checks in `tests.yml` trustworthy: the install no longer pipes through `tee` (which masked pip failures under the default shell), and the jobs verify the build by importing the compiled modules directly instead of grepping build logs for meson message strings. The no-BLAS job now only accepts the two expected modules as missing (`ModuleNotFoundError` with a matching name) rather than swallowing any `ImportError`.

Also replaces the errors-only pylint job with Ruff (pinned to 0.15.21) scoped to correctness rules (`E9`, `F`, `LOG`, `RUF100`), grandfathering pre-existing unused imports/locals in `libact/` and `examples/`, and cleans up a duplicate/unused import in `docs/conf.py`. `ruff check` passes on this branch. The lint workflow/job names changed, so any branch-protection required checks referencing the old names need updating.